### PR TITLE
Use mixed-addition for Schnorr scalar multiplication steps

### DIFF
--- a/src/schnorr/air.rs
+++ b/src/schnorr/air.rs
@@ -403,8 +403,7 @@ pub fn evaluate_constraints<E: FieldElement + From<BaseElement>>(
     let generator_point: Vec<E> = GENERATOR.iter().map(|&coord| coord.into()).collect();
 
     // Point to be used in the double-and-add operations of registers [PROJECTIVE_POINT_WIDTH + 1..PROJECTIVE_POINT_WIDTH * 2 + 1] (h.P)
-    let mut pkey_point: Vec<E> = pkey_point.to_vec();
-    pkey_point.extend_from_slice(&[E::ONE, E::ZERO, E::ZERO, E::ZERO, E::ZERO, E::ZERO]); // z(P)
+    let pkey_point: Vec<E> = pkey_point.to_vec();
 
     // When scalar_mult_flag = 1, constraints for a double-and-add
     // step are enforced on the dedicated registers for S and h.P,
@@ -418,7 +417,7 @@ pub fn evaluate_constraints<E: FieldElement + From<BaseElement>>(
         doubling_flag,
     );
 
-    ecc::enforce_point_addition(
+    ecc::enforce_point_addition_mixed(
         &mut result[..PROJECTIVE_POINT_WIDTH + 1],
         &current[..PROJECTIVE_POINT_WIDTH + 1],
         &next[..PROJECTIVE_POINT_WIDTH + 1],
@@ -434,7 +433,7 @@ pub fn evaluate_constraints<E: FieldElement + From<BaseElement>>(
         doubling_flag,
     );
 
-    ecc::enforce_point_addition(
+    ecc::enforce_point_addition_mixed(
         &mut result[PROJECTIVE_POINT_WIDTH + 1..2 * PROJECTIVE_POINT_WIDTH + 2],
         &current[PROJECTIVE_POINT_WIDTH + 1..2 * PROJECTIVE_POINT_WIDTH + 2],
         &next[PROJECTIVE_POINT_WIDTH + 1..2 * PROJECTIVE_POINT_WIDTH + 2],

--- a/src/schnorr/trace.rs
+++ b/src/schnorr/trace.rs
@@ -68,7 +68,7 @@ pub fn init_sig_verification_state(
 pub fn update_sig_verification_state(
     step: usize,
     message: [BaseElement; AFFINE_POINT_WIDTH * 2 + 4],
-    pkey_point: [BaseElement; PROJECTIVE_POINT_WIDTH],
+    pkey_point: [BaseElement; AFFINE_POINT_WIDTH],
     s_bits: &BitSlice<Lsb0, u8>,
     h_bits: &BitSlice<Lsb0, u8>,
     state: &mut [BaseElement],
@@ -125,8 +125,11 @@ pub fn update_sig_verification_state(
                     0,
                 );
             } else {
-                ecc::apply_point_addition(&mut state[0..PROJECTIVE_POINT_WIDTH + 1], &GENERATOR);
-                ecc::apply_point_addition(
+                ecc::apply_point_addition_mixed(
+                    &mut state[0..PROJECTIVE_POINT_WIDTH + 1],
+                    &GENERATOR,
+                );
+                ecc::apply_point_addition_mixed(
                     &mut state[PROJECTIVE_POINT_WIDTH + 1..2 * PROJECTIVE_POINT_WIDTH + 2],
                     &pkey_point,
                 );
@@ -157,10 +160,9 @@ pub fn update_sig_verification_state(
 pub fn build_sig_info(
     message: &[BaseElement; AFFINE_POINT_WIDTH * 2 + 4],
     signature: &([BaseElement; POINT_COORDINATE_WIDTH], Scalar),
-) -> ([BaseElement; PROJECTIVE_POINT_WIDTH], [u8; 32], [u8; 32]) {
-    let mut pkey_point = [BaseElement::ZERO; PROJECTIVE_POINT_WIDTH];
-    pkey_point[..AFFINE_POINT_WIDTH].clone_from_slice(&message[..AFFINE_POINT_WIDTH]);
-    pkey_point[AFFINE_POINT_WIDTH] = BaseElement::ONE;
+) -> ([BaseElement; AFFINE_POINT_WIDTH], [u8; 32], [u8; 32]) {
+    let mut pkey_point = [BaseElement::ZERO; AFFINE_POINT_WIDTH];
+    pkey_point.clone_from_slice(&message[..AFFINE_POINT_WIDTH]);
     let s_bytes = signature.1.to_bytes();
 
     let h = super::hash_message(signature.0, *message);

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -20,8 +20,7 @@ use winterfell::iterators::*;
 
 use merkle_const::TRANSACTION_CYCLE_LENGTH as MERKLE_UPDATE_LENGTH;
 use schnorr_const::{
-    AFFINE_POINT_WIDTH, POINT_COORDINATE_WIDTH, PROJECTIVE_POINT_WIDTH,
-    SIG_CYCLE_LENGTH as SCHNORR_LENGTH,
+    AFFINE_POINT_WIDTH, POINT_COORDINATE_WIDTH, SIG_CYCLE_LENGTH as SCHNORR_LENGTH,
 };
 
 // TRACE GENERATOR
@@ -155,7 +154,7 @@ pub fn update_transaction_state(
     sig_bits: &BitSlice<Lsb0, u8>,
     sig_hash_bits: &BitSlice<Lsb0, u8>,
     message: [BaseElement; AFFINE_POINT_WIDTH * 2 + 4],
-    pkey_point: [BaseElement; PROJECTIVE_POINT_WIDTH],
+    pkey_point: [BaseElement; AFFINE_POINT_WIDTH],
     state: &mut [BaseElement],
 ) {
     let merkle_update_flag = step < MERKLE_UPDATE_LENGTH - 1;


### PR DESCRIPTION
We currently perform pure Projective coordinates based group operations in Schnorr signature verification while the "added" points are either hardcoded (generator) or given as affine coordinates (public keys stored in Merkle leaves). It makes more sense to use mixed addition for the scalar multiplications as it saves some field additions.

The saving is light, increasing with the number of transactions, between ~0.5% to 1.2% on average for N = 32 to 512.