### PR TITLE
Adapt with latest winterfell changes

### DIFF
--- a/src/air.rs
+++ b/src/air.rs
@@ -68,7 +68,7 @@ pub struct TransactionAir {
 }
 
 impl Air for TransactionAir {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = PublicInputs;
 
     // CONSTRUCTOR
@@ -107,11 +107,11 @@ impl Air for TransactionAir {
         }
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         frame: &EvaluationFrame<E>,
         periodic_values: &[E],
@@ -172,7 +172,7 @@ impl Air for TransactionAir {
         )
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         // Assert the presence of the appropriate initial and final tree roots
         let last_step = self.trace_length() - 1;
         vec![
@@ -183,7 +183,7 @@ impl Air for TransactionAir {
         ]
     }
 
-    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseElement>> {
+    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseField>> {
         periodic_columns()
     }
 }

--- a/src/merkle/init/air.rs
+++ b/src/merkle/init/air.rs
@@ -44,7 +44,7 @@ pub struct PreMerkleAir {
 }
 
 impl Air for PreMerkleAir {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = PublicInputs;
 
     // CONSTRUCTOR
@@ -61,11 +61,11 @@ impl Air for PreMerkleAir {
         }
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         frame: &EvaluationFrame<E>,
         periodic_values: &[E],
@@ -83,7 +83,7 @@ impl Air for PreMerkleAir {
         evaluate_constraints(result, current, next, ark, FieldElement::ONE);
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         let mut assertions = vec![];
         //check initial sender values against public inputs
         for i in 0..AFFINE_POINT_WIDTH + 2 {
@@ -144,7 +144,7 @@ impl Air for PreMerkleAir {
         assertions
     }
 
-    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseElement>> {
+    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseField>> {
         periodic_columns()
     }
 }

--- a/src/merkle/init/prover.rs
+++ b/src/merkle/init/prover.rs
@@ -1,0 +1,91 @@
+use super::constants::*;
+use winterfell::{math::fields::f63::BaseElement, ProofOptions, Prover, Trace, TraceTable};
+
+use super::trace::*;
+use super::PreMerkleAir;
+use super::PublicInputs;
+
+// MERKLE INIT PROVER
+// ================================================================================================
+
+pub struct PreMerkleProver {
+    options: ProofOptions,
+}
+
+impl PreMerkleProver {
+    pub fn new(options: ProofOptions) -> Self {
+        Self { options }
+    }
+
+    pub fn build_trace(
+        &self,
+        s_inputs: [BaseElement; AFFINE_POINT_WIDTH + 2],
+        r_inputs: [BaseElement; AFFINE_POINT_WIDTH + 2],
+        delta: BaseElement,
+    ) -> TraceTable<BaseElement> {
+        // allocate memory to hold the trace table
+        let mut trace = TraceTable::new(TRACE_WIDTH, TRANSACTION_CYCLE_LENGTH);
+
+        trace.fill(
+            |state| {
+                // initialize first state of the computation
+                init_merkle_initialization_state(state, s_inputs, r_inputs, delta);
+            },
+            |step, state| {
+                // execute the transition function for all steps
+                update_merkle_initialization_state(step, state);
+            },
+        );
+
+        trace
+    }
+}
+
+impl Prover for PreMerkleProver {
+    type BaseField = BaseElement;
+    type Air = PreMerkleAir;
+    type Trace = TraceTable<BaseElement>;
+
+    fn get_pub_inputs(&self, trace: &Self::Trace) -> PublicInputs {
+        PublicInputs {
+            s_inputs: [
+                trace.get(SENDER_INITIAL_POS, 0),
+                trace.get(SENDER_INITIAL_POS + 1, 0),
+                trace.get(SENDER_INITIAL_POS + 2, 0),
+                trace.get(SENDER_INITIAL_POS + 3, 0),
+                trace.get(SENDER_INITIAL_POS + 4, 0),
+                trace.get(SENDER_INITIAL_POS + 5, 0),
+                trace.get(SENDER_INITIAL_POS + 6, 0),
+                trace.get(SENDER_INITIAL_POS + 7, 0),
+                trace.get(SENDER_INITIAL_POS + 8, 0),
+                trace.get(SENDER_INITIAL_POS + 9, 0),
+                trace.get(SENDER_INITIAL_POS + 10, 0),
+                trace.get(SENDER_INITIAL_POS + 11, 0),
+                trace.get(SENDER_INITIAL_POS + 12, 0),
+                trace.get(SENDER_INITIAL_POS + 13, 0),
+            ],
+            r_inputs: [
+                trace.get(RECEIVER_INITIAL_POS, 0),
+                trace.get(RECEIVER_INITIAL_POS + 1, 0),
+                trace.get(RECEIVER_INITIAL_POS + 2, 0),
+                trace.get(RECEIVER_INITIAL_POS + 3, 0),
+                trace.get(RECEIVER_INITIAL_POS + 4, 0),
+                trace.get(RECEIVER_INITIAL_POS + 5, 0),
+                trace.get(RECEIVER_INITIAL_POS + 6, 0),
+                trace.get(RECEIVER_INITIAL_POS + 7, 0),
+                trace.get(RECEIVER_INITIAL_POS + 8, 0),
+                trace.get(RECEIVER_INITIAL_POS + 9, 0),
+                trace.get(RECEIVER_INITIAL_POS + 10, 0),
+                trace.get(RECEIVER_INITIAL_POS + 11, 0),
+                trace.get(RECEIVER_INITIAL_POS + 12, 0),
+                trace.get(RECEIVER_INITIAL_POS + 13, 0),
+            ],
+            delta: trace.get(RECEIVER_UPDATED_POS + AFFINE_POINT_WIDTH, 0)
+                - trace.get(RECEIVER_INITIAL_POS + AFFINE_POINT_WIDTH, 0),
+        }
+    }
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+}

--- a/src/merkle/init/trace.rs
+++ b/src/merkle/init/trace.rs
@@ -7,37 +7,9 @@
 // except according to those terms.
 
 use super::constants::*;
-use winterfell::{
-    math::{fields::f63::BaseElement, FieldElement},
-    ExecutionTrace,
-};
+use winterfell::math::{fields::f63::BaseElement, FieldElement};
 
 use crate::utils::rescue;
-
-// TRACE BUILDER
-// ------------------------------------------------------------------------------------------------
-
-pub(crate) fn build_trace(
-    s_inputs: [BaseElement; AFFINE_POINT_WIDTH + 2],
-    r_inputs: [BaseElement; AFFINE_POINT_WIDTH + 2],
-    delta: BaseElement,
-) -> ExecutionTrace<BaseElement> {
-    // allocate memory to hold the trace table
-    let mut trace = ExecutionTrace::new(TRACE_WIDTH, TRANSACTION_CYCLE_LENGTH);
-
-    trace.fill(
-        |state| {
-            // initialize first state of the computation
-            init_merkle_initialization_state(state, s_inputs, r_inputs, delta);
-        },
-        |step, state| {
-            // execute the transition function for all steps
-            update_merkle_initialization_state(step, state);
-        },
-    );
-
-    trace
-}
 
 // TRACE INITIALIZATION
 // ================================================================================================

--- a/src/merkle/update/air.rs
+++ b/src/merkle/update/air.rs
@@ -40,7 +40,7 @@ pub struct MerkleAir {
 }
 
 impl Air for MerkleAir {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = PublicInputs;
 
     // CONSTRUCTOR
@@ -56,11 +56,11 @@ impl Air for MerkleAir {
         }
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         frame: &EvaluationFrame<E>,
         periodic_values: &[E],
@@ -145,7 +145,7 @@ impl Air for MerkleAir {
         );
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         // assert that Merkle path resolves to the tree root, and that hash capacity
         // registers are reset to ZERO every 8 steps
         // Now we must also resolve to the new root and the next registers are also
@@ -171,7 +171,7 @@ impl Air for MerkleAir {
         vec
     }
 
-    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseElement>> {
+    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseField>> {
         periodic_columns()
     }
 }

--- a/src/merkle/update/prover.rs
+++ b/src/merkle/update/prover.rs
@@ -1,0 +1,113 @@
+use super::constants::*;
+use winterfell::{
+    math::{fields::f63::BaseElement, FieldElement},
+    ProofOptions, Prover, Trace, TraceTable,
+};
+
+use super::trace::*;
+use super::MerkleAir;
+use super::PublicInputs;
+
+use crate::TransactionMetadata;
+
+// MERKLE UPDATE PROVER
+// ================================================================================================
+
+pub struct MerkleProver {
+    options: ProofOptions,
+}
+
+impl MerkleProver {
+    pub fn new(options: ProofOptions) -> Self {
+        Self { options }
+    }
+
+    pub fn build_trace(&self, tx_metadata: &TransactionMetadata) -> TraceTable<BaseElement> {
+        let initial_roots = &tx_metadata.initial_roots;
+        let s_old_values = &tx_metadata.s_old_values;
+        let r_old_values = &tx_metadata.r_old_values;
+        let s_indices = &tx_metadata.s_indices;
+        let r_indices = &tx_metadata.r_indices;
+        let s_paths = &tx_metadata.s_paths;
+        let r_paths = &tx_metadata.r_paths;
+        let deltas = &tx_metadata.deltas;
+
+        let num_transactions = tx_metadata.initial_roots.len();
+
+        // allocate memory to hold the trace table
+        let mut trace = TraceTable::new(TRACE_WIDTH, num_transactions * TRANSACTION_CYCLE_LENGTH);
+
+        // Apply the same init and update steps for each separate transaction
+        trace
+            .fragments(TRANSACTION_CYCLE_LENGTH)
+            .for_each(|mut merkle_trace| {
+                let i = merkle_trace.index();
+
+                merkle_trace.fill(
+                    |state| {
+                        init_merkle_update_state(
+                            initial_roots[i],
+                            s_old_values[i],
+                            r_old_values[i],
+                            deltas[i],
+                            state,
+                        );
+                    },
+                    |step, state| {
+                        update_merkle_update_state(
+                            step,
+                            s_indices[i],
+                            r_indices[i],
+                            s_paths[i].clone(),
+                            r_paths[i].clone(),
+                            state,
+                        );
+                    },
+                )
+            });
+
+        // set index bit at the second step to one; this still results in a valid execution trace
+        // because actual index bits are inserted into the trace after step 7, but it ensures
+        // that there are no repeating patterns in the index bit register, and thus the degree
+        // of the index bit constraint is stable.
+        trace.set(SENDER_BIT_POS, 1, BaseElement::ONE);
+        trace.set(RECEIVER_BIT_POS, 1, BaseElement::ONE);
+
+        trace
+    }
+}
+
+impl Prover for MerkleProver {
+    type BaseField = BaseElement;
+    type Air = MerkleAir;
+    type Trace = TraceTable<BaseElement>;
+
+    fn get_pub_inputs(&self, trace: &Self::Trace) -> PublicInputs {
+        let last_step = trace.length() - 1;
+
+        PublicInputs {
+            initial_root: [
+                trace.get(PREV_TREE_ROOT_POS, 0),
+                trace.get(PREV_TREE_ROOT_POS + 1, 0),
+                trace.get(PREV_TREE_ROOT_POS + 2, 0),
+                trace.get(PREV_TREE_ROOT_POS + 3, 0),
+                trace.get(PREV_TREE_ROOT_POS + 4, 0),
+                trace.get(PREV_TREE_ROOT_POS + 5, 0),
+                trace.get(PREV_TREE_ROOT_POS + 6, 0),
+            ],
+            final_root: [
+                trace.get(PREV_TREE_ROOT_POS, last_step),
+                trace.get(PREV_TREE_ROOT_POS + 1, last_step),
+                trace.get(PREV_TREE_ROOT_POS + 2, last_step),
+                trace.get(PREV_TREE_ROOT_POS + 3, last_step),
+                trace.get(PREV_TREE_ROOT_POS + 4, last_step),
+                trace.get(PREV_TREE_ROOT_POS + 5, last_step),
+                trace.get(PREV_TREE_ROOT_POS + 6, last_step),
+            ],
+        }
+    }
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+}

--- a/src/merkle/update/trace.rs
+++ b/src/merkle/update/trace.rs
@@ -8,75 +8,13 @@
 
 use super::constants::*;
 use crate::utils::rescue::{self, RATE_WIDTH};
-use crate::TransactionMetadata;
-use winterfell::{
-    math::{fields::f63::BaseElement, FieldElement},
-    ExecutionTrace,
-};
+use winterfell::math::{fields::f63::BaseElement, FieldElement};
 
 #[cfg(feature = "concurrent")]
 use winterfell::iterators::*;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-
-// TRACE GENERATOR
-// ================================================================================================
-
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn build_trace(tx_metadata: &TransactionMetadata) -> ExecutionTrace<BaseElement> {
-    let initial_roots = &tx_metadata.initial_roots;
-    let s_old_values = &tx_metadata.s_old_values;
-    let r_old_values = &tx_metadata.r_old_values;
-    let s_indices = &tx_metadata.s_indices;
-    let r_indices = &tx_metadata.r_indices;
-    let s_paths = &tx_metadata.s_paths;
-    let r_paths = &tx_metadata.r_paths;
-    let deltas = &tx_metadata.deltas;
-
-    let num_transactions = tx_metadata.initial_roots.len();
-
-    // allocate memory to hold the trace table
-    let mut trace = ExecutionTrace::new(TRACE_WIDTH, num_transactions * TRANSACTION_CYCLE_LENGTH);
-
-    // Apply the same init and update steps for each separate transaction
-    trace
-        .fragments(TRANSACTION_CYCLE_LENGTH)
-        .for_each(|mut merkle_trace| {
-            let i = merkle_trace.index();
-
-            merkle_trace.fill(
-                |state| {
-                    init_merkle_update_state(
-                        initial_roots[i],
-                        s_old_values[i],
-                        r_old_values[i],
-                        deltas[i],
-                        state,
-                    );
-                },
-                |step, state| {
-                    update_merkle_update_state(
-                        step,
-                        s_indices[i],
-                        r_indices[i],
-                        s_paths[i].clone(),
-                        r_paths[i].clone(),
-                        state,
-                    );
-                },
-            )
-        });
-
-    // set index bit at the second step to one; this still results in a valid execution trace
-    // because actual index bits are inserted into the trace after step 7, but it ensures
-    // that there are no repeating patterns in the index bit register, and thus the degree
-    // of the index bit constraint is stable.
-    trace.set(SENDER_BIT_POS, 1, FieldElement::ONE);
-    trace.set(RECEIVER_BIT_POS, 1, FieldElement::ONE);
-
-    trace
-}
 
 // TRACE INITIALIZATION
 // ================================================================================================

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,0 +1,131 @@
+use bitvec::{order::Lsb0, view::AsBits};
+use winterfell::{math::fields::f63::BaseElement, ProofOptions, Prover, Trace, TraceTable};
+
+use super::constants::*;
+use super::schnorr;
+use super::trace::*;
+use super::PublicInputs;
+use super::TransactionAir;
+use super::TransactionMetadata;
+
+use merkle_const::PREV_TREE_ROOT_POS;
+use schnorr_const::AFFINE_POINT_WIDTH;
+
+// TRANSACTION PROVER
+// ================================================================================================
+
+pub struct TransactionProver {
+    options: ProofOptions,
+}
+
+impl TransactionProver {
+    pub fn new(options: ProofOptions) -> Self {
+        Self { options }
+    }
+
+    // The trace is composed as follows:
+    // (note that sigma here refers to sender_balance - delta)
+    //
+    // | 4 * HASH_STATE + 2 + HASH_RATE |      2 * AFF_POINT + 3      | number of registers
+    // |          merkle::init          | copy_keys_delta_sigma_nonce | sub-programs
+    // |         merkle::update         | copy_keys_delta_sigma_nonce |
+    // |         schnorr::init          | copy_keys_delta_sigma_nonce |
+    // |         schnorr::verif         | range_proof_delta_and_sigma |
+    pub fn build_trace(&self, tx_metadata: &TransactionMetadata) -> TraceTable<BaseElement> {
+        let initial_roots = &tx_metadata.initial_roots;
+        let s_old_values = &tx_metadata.s_old_values;
+        let r_old_values = &tx_metadata.r_old_values;
+        let s_indices = &tx_metadata.s_indices;
+        let r_indices = &tx_metadata.r_indices;
+        let s_paths = &tx_metadata.s_paths;
+        let r_paths = &tx_metadata.r_paths;
+        let deltas = &tx_metadata.deltas;
+        let signatures = &tx_metadata.signatures;
+        let num_transactions = tx_metadata.initial_roots.len();
+        // allocate memory to hold the trace table
+        let mut trace = TraceTable::new(TRACE_WIDTH, num_transactions * TRANSACTION_CYCLE_LENGTH);
+        trace
+            .fragments(TRANSACTION_CYCLE_LENGTH)
+            .for_each(|mut transaction_trace| {
+                let i = transaction_trace.index();
+                let delta_bytes = deltas[i].to_bytes();
+                let delta_bits = delta_bytes.as_bits::<Lsb0>();
+                let sigma_bytes = (s_old_values[i][AFFINE_POINT_WIDTH] - deltas[i]).to_bytes();
+                let sigma_bits = sigma_bytes.as_bits::<Lsb0>();
+                let message = super::build_tx_message(
+                    &s_old_values[i][0..AFFINE_POINT_WIDTH],
+                    &r_old_values[i][0..AFFINE_POINT_WIDTH],
+                    deltas[i],
+                    s_old_values[i][AFFINE_POINT_WIDTH + 1],
+                );
+                let (pkey_point, sig_bytes, sig_hash_bytes) =
+                    schnorr::build_sig_info(&message, &signatures[i]);
+                let sig_bits = sig_bytes.as_bits::<Lsb0>();
+                let sig_hash_bits = sig_hash_bytes.as_bits::<Lsb0>();
+                transaction_trace.fill(
+                    |state| {
+                        init_transaction_state(
+                            initial_roots[i],
+                            s_old_values[i],
+                            r_old_values[i],
+                            deltas[i],
+                            state,
+                        );
+                    },
+                    |step, state| {
+                        update_transaction_state(
+                            step,
+                            s_indices[i],
+                            r_indices[i],
+                            s_paths[i].clone(),
+                            r_paths[i].clone(),
+                            delta_bits,
+                            sigma_bits,
+                            signatures[i],
+                            sig_bits,
+                            sig_hash_bits,
+                            message,
+                            pkey_point,
+                            state,
+                        );
+                    },
+                )
+            });
+        trace
+    }
+}
+
+impl Prover for TransactionProver {
+    type BaseField = BaseElement;
+    type Air = TransactionAir;
+    type Trace = TraceTable<BaseElement>;
+
+    fn get_pub_inputs(&self, trace: &Self::Trace) -> PublicInputs {
+        let last_step = trace.length() - 1;
+
+        PublicInputs {
+            initial_root: [
+                trace.get(PREV_TREE_ROOT_POS, 0),
+                trace.get(PREV_TREE_ROOT_POS + 1, 0),
+                trace.get(PREV_TREE_ROOT_POS + 2, 0),
+                trace.get(PREV_TREE_ROOT_POS + 3, 0),
+                trace.get(PREV_TREE_ROOT_POS + 4, 0),
+                trace.get(PREV_TREE_ROOT_POS + 5, 0),
+                trace.get(PREV_TREE_ROOT_POS + 6, 0),
+            ],
+            final_root: [
+                trace.get(PREV_TREE_ROOT_POS, last_step),
+                trace.get(PREV_TREE_ROOT_POS + 1, last_step),
+                trace.get(PREV_TREE_ROOT_POS + 2, last_step),
+                trace.get(PREV_TREE_ROOT_POS + 3, last_step),
+                trace.get(PREV_TREE_ROOT_POS + 4, last_step),
+                trace.get(PREV_TREE_ROOT_POS + 5, last_step),
+                trace.get(PREV_TREE_ROOT_POS + 6, last_step),
+            ],
+        }
+    }
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+}

--- a/src/range/prover.rs
+++ b/src/range/prover.rs
@@ -1,0 +1,84 @@
+use bitvec::{order::Lsb0, slice::BitSlice, view::AsBits};
+use winterfell::{
+    math::{fields::f63::BaseElement, FieldElement},
+    ProofOptions, Prover, Trace, TraceTable,
+};
+
+use super::air::TRACE_WIDTH;
+use super::field;
+use super::PublicInputs;
+use super::RangeProofAir;
+
+// RANGE PROVER
+// ================================================================================================
+
+pub struct RangeProver {
+    options: ProofOptions,
+}
+
+impl RangeProver {
+    pub fn new(options: ProofOptions) -> Self {
+        Self { options }
+    }
+
+    pub fn build_trace(&self, number: BaseElement, range_log: usize) -> TraceTable<BaseElement> {
+        // allocate memory to hold the trace table
+        let trace_length = range_log;
+        let mut trace = TraceTable::new(TRACE_WIDTH, trace_length);
+
+        let number_bytes = number.to_bytes();
+        let number_bits = number_bytes.as_bits::<Lsb0>();
+
+        trace.fill(
+            |state| {
+                init_range_verification_state(state);
+            },
+            |step, state| {
+                // execute the transition function for all steps
+                update_range_verification_state(step, range_log - 1, number_bits, state);
+            },
+        );
+
+        trace
+    }
+}
+
+impl Prover for RangeProver {
+    type BaseField = BaseElement;
+    type Air = RangeProofAir;
+    type Trace = TraceTable<BaseElement>;
+
+    fn get_pub_inputs(&self, trace: &Self::Trace) -> PublicInputs {
+        PublicInputs {
+            number: trace.get(1, trace.length() - 1),
+        }
+    }
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+}
+
+// TRACE INITIALIZATION
+// ================================================================================================
+
+pub(crate) fn init_range_verification_state(state: &mut [BaseElement]) {
+    // initialize first state of the computation
+    state[0] = BaseElement::ZERO; // bit
+    state[1] = BaseElement::ZERO; // accumulated value
+}
+
+// TRACE TRANSITION FUNCTION
+// ================================================================================================
+
+pub(crate) fn update_range_verification_state(
+    step: usize,
+    range_log: usize,
+    bits: &BitSlice<Lsb0, u8>,
+    state: &mut [BaseElement],
+) {
+    if step < range_log {
+        state[0] = BaseElement::from(bits[range_log - 1 - step] as u8);
+        field::apply_double_and_add_step(state, 1, 0);
+    }
+}

--- a/src/schnorr/air.rs
+++ b/src/schnorr/air.rs
@@ -45,7 +45,7 @@ pub struct SchnorrAir {
 }
 
 impl Air for SchnorrAir {
-    type BaseElement = BaseElement;
+    type BaseField = BaseElement;
     type PublicInputs = PublicInputs;
 
     // CONSTRUCTOR
@@ -60,11 +60,11 @@ impl Air for SchnorrAir {
         }
     }
 
-    fn context(&self) -> &AirContext<Self::BaseElement> {
+    fn context(&self) -> &AirContext<Self::BaseField> {
         &self.context
     }
 
-    fn evaluate_transition<E: FieldElement + From<Self::BaseElement>>(
+    fn evaluate_transition<E: FieldElement + From<Self::BaseField>>(
         &self,
         frame: &EvaluationFrame<E>,
         periodic_values: &[E],
@@ -108,7 +108,7 @@ impl Air for SchnorrAir {
         );
     }
 
-    fn get_assertions(&self) -> Vec<Assertion<Self::BaseElement>> {
+    fn get_assertions(&self) -> Vec<Assertion<Self::BaseField>> {
         let signatures = transpose_signatures(&self.signatures);
         // Assert starting and ending values
         let mut assertions = vec![];
@@ -226,7 +226,7 @@ impl Air for SchnorrAir {
         assertions
     }
 
-    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseElement>> {
+    fn get_periodic_column_values(&self) -> Vec<Vec<Self::BaseField>> {
         // Start with empty periodic columns
         let mut columns = vec![Vec::new(); POINT_COORDINATE_WIDTH + PROJECTIVE_POINT_WIDTH + 3];
         // Stitch in the periodic columns applicable to all uses of Schnorr

--- a/src/schnorr/prover.rs
+++ b/src/schnorr/prover.rs
@@ -1,0 +1,87 @@
+use super::constants::*;
+use bitvec::{order::Lsb0, view::AsBits};
+use winterfell::{
+    math::{curves::curve_f63::Scalar, fields::f63::BaseElement},
+    ProofOptions, Prover, TraceTable,
+};
+
+use super::trace::*;
+use super::PublicInputs;
+use super::SchnorrAir;
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+// SCHNORR PROVER
+// ================================================================================================
+
+pub struct SchnorrProver {
+    options: ProofOptions,
+    messages: Vec<[BaseElement; AFFINE_POINT_WIDTH * 2 + 4]>,
+    signatures: Vec<([BaseElement; POINT_COORDINATE_WIDTH], Scalar)>,
+}
+
+impl SchnorrProver {
+    pub fn new(
+        options: ProofOptions,
+        messages: Vec<[BaseElement; AFFINE_POINT_WIDTH * 2 + 4]>,
+        signatures: Vec<([BaseElement; POINT_COORDINATE_WIDTH], Scalar)>,
+    ) -> Self {
+        Self {
+            options,
+            messages,
+            signatures,
+        }
+    }
+
+    pub fn build_trace(&self) -> TraceTable<BaseElement> {
+        // allocate memory to hold the trace table
+        let trace_length = SIG_CYCLE_LENGTH * self.messages.len();
+        let mut trace = TraceTable::new(TRACE_WIDTH, trace_length);
+        trace.fragments(SIG_CYCLE_LENGTH).for_each(|mut sig_trace| {
+            let i = sig_trace.index();
+            let (pkey_point, s_bytes, h_bytes) =
+                build_sig_info(&self.messages[i], &self.signatures[i]);
+            let s_bits = s_bytes.as_bits::<Lsb0>();
+            let h_bits = h_bytes.as_bits::<Lsb0>();
+            sig_trace.fill(
+                |state| {
+                    init_sig_verification_state(self.signatures[i], state);
+                },
+                |step, state| {
+                    update_sig_verification_state(
+                        step,
+                        self.messages[i],
+                        pkey_point,
+                        s_bits,
+                        h_bits,
+                        state,
+                    );
+                },
+            );
+        });
+        trace
+    }
+}
+
+impl Prover for SchnorrProver {
+    type BaseField = BaseElement;
+    type Air = SchnorrAir;
+    type Trace = TraceTable<BaseElement>;
+
+    // This method should use the existing trace to extract the public inputs to be given
+    // to the verifier. As the Schnorr sub-AIR program is not intended to be used as a
+    // standalone AIR program, we bypass this here by storing directly the messages and signatures
+    // in the SchnorrProver struct. This is not used in the complete state transition Air program
+    // where only initial and final Merkle roots are provided to the verifier.
+    fn get_pub_inputs(&self, _trace: &Self::Trace) -> PublicInputs {
+        PublicInputs {
+            messages: self.messages.clone(),
+            signatures: self.signatures.clone(),
+        }
+    }
+
+    fn options(&self) -> &ProofOptions {
+        &self.options
+    }
+}

--- a/src/utils/ecc.rs
+++ b/src/utils/ecc.rs
@@ -405,44 +405,35 @@ fn compute_add_mixed<E: FieldElement + From<BaseElement>>(state: &mut [E], point
 
 #[inline(always)]
 pub(crate) fn square_fp2<E: FieldElement + From<BaseElement>>(a: &[E]) -> [E; 2] {
-    let self_c0 = a[0];
-    let self_c1 = a[1];
+    let aa = a[0].square();
+    let bb = a[1].square();
 
-    let aa = self_c0.square();
-    let bb = self_c1.square();
+    let tmp = a[0].sub(a[1]);
+    let tmp = tmp.square();
 
-    let tmp = self_c0.sub(self_c1);
-    let tmp = (&tmp).square();
+    let c0 = bb.double();
+    let c0 = c0.add(aa);
 
-    let c0 = (&bb).double();
-    let c0 = (&c0).add(aa);
-
-    let c1 = (&bb).add(c0);
-    let c1 = (&c1).sub(tmp);
+    let c1 = bb.add(c0);
+    let c1 = c1.sub(tmp);
 
     [c0, c1]
 }
 
 #[inline(always)]
 pub(crate) fn mul_fp2<E: FieldElement + From<BaseElement>>(a: &[E], b: &[E]) -> [E; 2] {
-    let self_c0 = a[0];
-    let self_c1 = a[1];
+    let aa = a[0].mul(b[0]);
+    let bb = a[1].mul(b[1]);
 
-    let other_c0 = b[0];
-    let other_c1 = b[1];
+    let tmp = a[0].sub(a[1]);
+    let tmp2 = b[1].sub(b[0]);
+    let tmp = tmp.mul(tmp2);
 
-    let aa = (&self_c0).mul(other_c0);
-    let bb = (&self_c1).mul(other_c1);
+    let c0 = bb.double();
+    let c0 = c0.add(aa);
 
-    let tmp = self_c0.sub(self_c1);
-    let tmp2 = other_c1.sub(other_c0);
-    let tmp = (&tmp).mul(tmp2);
-
-    let c0 = (&bb).double();
-    let c0 = (&c0).add(aa);
-
-    let c1 = (&bb).add(c0);
-    let c1 = (&c1).add(tmp);
+    let c1 = bb.add(c0);
+    let c1 = c1.add(tmp);
 
     [c0, c1]
 }

--- a/src/utils/periodic_columns.rs
+++ b/src/utils/periodic_columns.rs
@@ -52,7 +52,7 @@ use alloc::vec::Vec;
 /// );
 /// ```
 pub(crate) fn stitch(
-    original_columns: &mut Vec<Vec<BaseElement>>,
+    original_columns: &mut [Vec<BaseElement>],
     additional_columns: Vec<Vec<BaseElement>>,
     index_map: Vec<(usize, usize)>,
 ) {
@@ -122,7 +122,7 @@ pub(crate) fn stitch(
 /// );
 /// ```
 pub(crate) fn fill(
-    original_columns: &mut Vec<Vec<BaseElement>>,
+    original_columns: &mut [Vec<BaseElement>],
     additional_columns: Vec<Vec<BaseElement>>,
     index_map: Vec<(usize, usize)>,
     length: usize,
@@ -187,7 +187,7 @@ pub(crate) fn fill(
 /// );
 /// ```
 pub(crate) fn pad(
-    original_columns: &mut Vec<Vec<BaseElement>>,
+    original_columns: &mut [Vec<BaseElement>],
     indices: Vec<usize>,
     length: usize,
     pad_element: BaseElement,


### PR DESCRIPTION
Follow-up from https://github.com/Toposware/winterfell/pull/25.

The logic of the Schnorr Prover for extracting PublicInputs from the TraceTable has been tweaked, as it is only necessary to make Schnorr work as a standalone AIR program and is not necessary in the final AIR program anyway.